### PR TITLE
フッターの右側余白の原因調査

### DIFF
--- a/about.html
+++ b/about.html
@@ -12,8 +12,7 @@
 <body>
   <div id="header"></div>
   <div id="menubar-area"></div>
-  <div id="container">
-    <div id="contents">
+  <div id="contents">
       <main>
         <section>
           <div class="list-free">
@@ -74,9 +73,9 @@
           </table>
         </section>
       </main>
-    </div>
-    <div id="footer"></div>
   </div>
+
+  <div id="footer"></div>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
   <script src="js/common.js"></script>
   <script src="js/main.js"></script>

--- a/contact.html
+++ b/contact.html
@@ -12,7 +12,7 @@
 <body>
   <div id="header"></div>
   <div id="menubar-area"></div>
-  <div id="container">
+  <div id="contents">
     <main>
         <section>
           
@@ -24,9 +24,9 @@
 			  <p style="text-align: center;">Googleフォームが起動します</p>
         </section>
       </main>
-    </div>
-    <div id="footer"></div>
   </div>
+
+  <div id="footer"></div>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
   <script src="js/common.js"></script>
   <script src="js/main.js"></script>

--- a/musiclist.html
+++ b/musiclist.html
@@ -14,16 +14,15 @@
 <body>
 <div id="header"></div>
 <div id="menubar-area"></div>
-  <div id="container">
-    <div id="contents">
+  <div id="contents">
       <main>
         <section>
           <h2 class="c box1">過去の練習曲</h2>
           <div id="tunes-container">読み込み中...</div>
         </section>
       </main>
-    </div>
   </div>
+
 <div id="footer"></div>
 
 <!--jQueryの読み込み-->

--- a/profile.html
+++ b/profile.html
@@ -12,8 +12,7 @@
 <body>
   <div id="header"></div>
   <div id="menubar-area"></div>
-  <div id="container">
-    <div id="contents">
+  <div id="contents">
       <main>
         <section>
           <div class="list-free">
@@ -53,9 +52,9 @@
           </div>
         </section>
       </main>
-    </div>
-    <div id="footer"></div>
   </div>
+
+  <div id="footer"></div>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
   <script src="js/common.js"></script>
   <script src="js/main.js"></script>


### PR DESCRIPTION
Remove `#container` div from HTML files to fix footer right margin issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-b6c961cf-964b-4984-9772-2d93c12d7c81">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b6c961cf-964b-4984-9772-2d93c12d7c81">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>