### PR TITLE
Fix right white space on green footer

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -227,9 +227,10 @@ footer {
 	padding: var(--global-space);
 	color: var(--primary-inverse-color); /* ヘッダーと同じ白色テキスト */
 	background: var(--primary-color); /* ヘッダーと同じ緑色背景 */
-	width: 100vw; /* 画面幅いっぱいに表示 */
+	width: calc(100% + 2 * var(--global-space)); /* 親要素の幅 + 左右のマージン分 */
 	margin-left: calc(-1 * var(--global-space)); /* 左側のパディングを相殺 */
 	margin-right: calc(-1 * var(--global-space)); /* 右側のパディングを相殺 */
+	box-sizing: border-box; /* パディングとボーダーを幅に含める */
 }
 
 /* フッター内のリンクスタイル */


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes the white space on the right side of the footer by adjusting its width calculation and adding `box-sizing: border-box`.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous `width: 100vw` combined with negative margins caused a horizontal scrollbar and a visible gap on the right, as `100vw` does not account for the vertical scrollbar's width. The new `calc` value ensures the footer correctly spans the entire content area, preventing the unwanted gap.

---
<a href="https://cursor.com/background-agent?bcId=bc-7f8e629e-1d8d-4c97-ac4a-bb3b6c74a113">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7f8e629e-1d8d-4c97-ac4a-bb3b6c74a113">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>